### PR TITLE
Adding integration of derived source feature across diff paths

### DIFF
--- a/modules/reindex/src/test/java/org/opensearch/index/reindex/ReindexBasicTests.java
+++ b/modules/reindex/src/test/java/org/opensearch/index/reindex/ReindexBasicTests.java
@@ -181,20 +181,20 @@ public class ReindexBasicTests extends ReindexTestCase {
     }
 
     public void testReindexWithDerivedSource() throws Exception {
-        // Create source index with _source option set as derived
+        // Create source index with derived source setting enabled
         String sourceIndexMapping = """
             {
                 "settings": {
                     "index": {
                         "number_of_shards": 1,
-                        "number_of_replicas": 0
+                        "number_of_replicas": 0,
+                        "derived_source": {
+                            "enabled": true
+                        }
                     }
                 },
                 "mappings": {
                     "_doc": {
-                        "_source": {
-                            "enabled": "derived"
-                        },
                         "properties": {
                             "foo": {
                                 "type": "keyword",

--- a/server/src/internalClusterTest/java/org/opensearch/get/GetActionIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/get/GetActionIT.java
@@ -790,20 +790,20 @@ public class GetActionIT extends OpenSearchIntegTestCase {
     }
 
     public void testDerivedSourceSimple() throws IOException {
-        // Create index with _source option as derived source
+        // Create index with derived source index setting enabled
         String createIndexSource = """
             {
                 "settings": {
                     "index": {
                         "number_of_shards": 2,
-                        "number_of_replicas": 0
+                        "number_of_replicas": 0,
+                        "derived_source": {
+                            "enabled": true
+                        }
                     }
                 },
                 "mappings": {
                     "_doc": {
-                        "_source": {
-                            "enabled": "derived"
-                        },
                         "properties": {
                             "geopoint_field": {
                                 "type": "geo_point"
@@ -895,9 +895,6 @@ public class GetActionIT extends OpenSearchIntegTestCase {
         // Create mapping with properly closed objects
         String mapping = XContentFactory.jsonBuilder()
             .startObject()
-            .startObject("_source")
-            .field("enabled", "derived")
-            .endObject()
             .startObject("properties")
             .startObject("level1")
             .startObject("properties")
@@ -923,8 +920,12 @@ public class GetActionIT extends OpenSearchIntegTestCase {
 
         // Create index with settings and mapping
         assertAcked(
-            prepareCreate("test_derive").setSettings(Settings.builder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0))
-                .setMapping(mapping)
+            prepareCreate("test_derive").setSettings(
+                Settings.builder()
+                    .put("index.number_of_shards", 1)
+                    .put("index.number_of_replicas", 0)
+                    .put("index.derived_source.enabled", true)
+            ).setMapping(mapping)
         );
         ensureGreen();
 

--- a/server/src/internalClusterTest/java/org/opensearch/search/simple/SimpleSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/simple/SimpleSearchIT.java
@@ -730,20 +730,20 @@ public class SimpleSearchIT extends ParameterizedStaticSettingsOpenSearchIntegTe
     }
 
     public void testDerivedSourceSearch() throws Exception {
-        // Create index with _source option set as derived
+        // Create index with derived source setting enabled
         String createIndexSource = """
             {
                 "settings": {
                     "index": {
                         "number_of_shards": 2,
-                        "number_of_replicas": 0
+                        "number_of_replicas": 0,
+                        "derived_source": {
+                            "enabled": true
+                        }
                     }
                 },
                 "mappings": {
                     "_doc": {
-                        "_source": {
-                            "enabled": "derived"
-                        },
                         "properties": {
                             "geopoint_field": {
                                 "type": "geo_point"

--- a/server/src/internalClusterTest/java/org/opensearch/search/simple/SimpleSearchIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/search/simple/SimpleSearchIT.java
@@ -45,11 +45,13 @@ import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.geometry.utils.Geohash;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.query.ConstantScoreQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.search.SearchHit;
 import org.opensearch.search.rescore.QueryRescorerBuilder;
 import org.opensearch.search.sort.SortOrder;
 import org.opensearch.test.ParameterizedStaticSettingsOpenSearchIntegTestCase;
@@ -59,11 +61,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
 import static org.opensearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
+import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.opensearch.index.query.QueryBuilders.boolQuery;
 import static org.opensearch.index.query.QueryBuilders.matchAllQuery;
 import static org.opensearch.index.query.QueryBuilders.queryStringQuery;
@@ -722,6 +727,135 @@ public class SimpleSearchIT extends ParameterizedStaticSettingsOpenSearchIntegTe
                     + "] index level setting."
             )
         );
+    }
+
+    public void testDerivedSourceSearch() throws Exception {
+        // Create index with _source option set as derived
+        String createIndexSource = """
+            {
+                "settings": {
+                    "index": {
+                        "number_of_shards": 2,
+                        "number_of_replicas": 0
+                    }
+                },
+                "mappings": {
+                    "_doc": {
+                        "_source": {
+                            "enabled": "derived"
+                        },
+                        "properties": {
+                            "geopoint_field": {
+                                "type": "geo_point"
+                            },
+                            "keyword_field": {
+                                "type": "keyword"
+                            },
+                            "numeric_field": {
+                                "type": "long"
+                            },
+                            "date_field": {
+                                "type": "date"
+                            },
+                            "bool_field": {
+                                "type": "boolean"
+                            },
+                            "ip_field": {
+                                "type": "ip"
+                            }
+                        }
+                    }
+                }
+            }""";
+
+        assertAcked(prepareCreate("test_derive").setSource(createIndexSource, MediaTypeRegistry.JSON));
+        ensureGreen();
+
+        // Index multiple documents
+        int numDocs = 10;
+        List<IndexRequestBuilder> builders = new ArrayList<>();
+        for (int i = 0; i < numDocs; i++) {
+            builders.add(
+                client().prepareIndex("test_derive")
+                    .setId(Integer.toString(i))
+                    .setSource(
+                        jsonBuilder().startObject()
+                            .field("geopoint_field", Geohash.stringEncode(40.0 + i, 75.0 + i))
+                            .field("keyword_field", "keyword_" + i)
+                            .field("numeric_field", i)
+                            .field("date_field", "2023-01-" + String.format(Locale.ROOT, "%02d", i + 1))
+                            .field("bool_field", i % 2 == 0)
+                            .field("ip_field", "192.168.1." + i)
+                            .endObject()
+                    )
+            );
+        }
+        indexRandom(true, builders);
+
+        // Test 1: Basic search with derived source
+        SearchResponse response = client().prepareSearch("test_derive").setQuery(QueryBuilders.matchAllQuery()).get();
+        assertNoFailures(response);
+        assertHitCount(response, numDocs);
+        for (SearchHit hit : response.getHits()) {
+            Map<String, Object> source = hit.getSourceAsMap();
+            assertNotNull("Derive source should be present", source);
+            int id = ((Number) source.get("numeric_field")).intValue();
+            assertEquals(Integer.toString(id), hit.getId());
+            assertEquals("keyword_" + id, source.get("keyword_field"));
+            assertEquals("192.168.1." + id, source.get("ip_field"));
+        }
+
+        // Test 2: Search with source filtering
+        response = client().prepareSearch("test_derive")
+            .setQuery(QueryBuilders.matchAllQuery())
+            .setFetchSource(new String[] { "keyword_field", "numeric_field" }, null)
+            .get();
+        assertNoFailures(response);
+        for (SearchHit hit : response.getHits()) {
+            Map<String, Object> source = hit.getSourceAsMap();
+            assertEquals("Source should only contain 2 fields", 2, source.size());
+            assertTrue(source.containsKey("keyword_field"));
+            assertTrue(source.containsKey("numeric_field"));
+        }
+
+        // Test 3: Search with range query
+        response = client().prepareSearch("test_derive").setQuery(QueryBuilders.rangeQuery("numeric_field").from(3).to(6)).get();
+        assertNoFailures(response);
+        assertHitCount(response, 4);
+        for (SearchHit hit : response.getHits()) {
+            int value = ((Number) hit.getSourceAsMap().get("numeric_field")).intValue();
+            assertTrue("Value should be between 3 and 6", value >= 3 && value <= 6);
+        }
+
+        // Test 4: Search with sorting on number field
+        response = client().prepareSearch("test_derive")
+            .setQuery(QueryBuilders.matchAllQuery())
+            .addSort("numeric_field", SortOrder.DESC)
+            .get();
+        assertNoFailures(response);
+        int lastValue = Integer.MAX_VALUE;
+        for (SearchHit hit : response.getHits()) {
+            int currentValue = ((Number) hit.getSourceAsMap().get("numeric_field")).intValue();
+            assertTrue("Results should be sorted in descending order", currentValue <= lastValue);
+            lastValue = currentValue;
+        }
+
+        // Test 5: Search with complex boolean query
+        response = client().prepareSearch("test_derive")
+            .setQuery(
+                QueryBuilders.boolQuery()
+                    .must(QueryBuilders.rangeQuery("numeric_field").gt(5))
+                    .must(QueryBuilders.termQuery("bool_field", true))
+            )
+            .get();
+        assertNoFailures(response);
+        for (SearchHit hit : response.getHits()) {
+            Map<String, Object> source = hit.getSourceAsMap();
+            int numValue = ((Number) source.get("numeric_field")).intValue();
+            boolean boolValue = (Boolean) source.get("bool_field");
+            assertTrue(numValue > 5);
+            assertTrue(boolValue);
+        }
     }
 
     private void assertWindowFails(SearchRequestBuilder search) {

--- a/server/src/internalClusterTest/java/org/opensearch/update/UpdateIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/update/UpdateIT.java
@@ -49,6 +49,8 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.geometry.utils.Geohash;
 import org.opensearch.index.MergePolicyProvider;
 import org.opensearch.index.engine.DocumentMissingException;
 import org.opensearch.index.engine.VersionConflictEngineException;
@@ -896,6 +898,197 @@ public class UpdateIT extends OpenSearchIntegTestCase {
                 assertThat(response.getVersion() + totalFailures, equalTo((long) ((numberOfUpdatesPerId * numberOfThreads * 2) + 1)));
             }
         }
+    }
+
+    public void testDerivedSourceWithUpdates() throws Exception {
+        // Create index with _source option set to derived
+        String createIndexSource = """
+            {
+                "settings": {
+                    "index": {
+                        "number_of_shards": 2,
+                        "number_of_replicas": 0,
+                        "refresh_interval": -1
+                    }
+                },
+                "mappings": {
+                    "_doc": {
+                        "_source": {
+                            "enabled": "derived"
+                        },
+                        "properties": {
+                            "geopoint_field": {
+                                "type": "geo_point"
+                            },
+                            "keyword_field": {
+                                "type": "keyword"
+                            },
+                            "numeric_field": {
+                                "type": "long"
+                            },
+                            "bool_field": {
+                                "type": "boolean"
+                            },
+                            "text_field": {
+                                "type": "text",
+                                "store": true
+                            }
+                        }
+                    }
+                }
+            }""";
+
+        assertAcked(prepareCreate("test_derive").setSource(createIndexSource, MediaTypeRegistry.JSON));
+        ensureGreen();
+
+        // Test 1: Basic Update with Script
+        UpdateResponse updateResponse = client().prepareUpdate("test_derive", "1")
+            .setScript(new Script(ScriptType.INLINE, UPDATE_SCRIPTS, FIELD_INC_SCRIPT, Collections.singletonMap("field", "numeric_field")))
+            .setUpsert(
+                jsonBuilder().startObject()
+                    .field("geopoint_field", Geohash.stringEncode(40.33, 75.98))
+                    .field("numeric_field", 1)
+                    .field("keyword_field", "initial")
+                    .field("bool_field", true)
+                    .field("text_field", "initial text")
+                    .endObject()
+            )
+            .setFetchSource(true)
+            .execute()
+            .actionGet();
+
+        assertThat(updateResponse.status(), equalTo(RestStatus.CREATED));
+        Map<String, Object> source = updateResponse.getGetResult().sourceAsMap();
+        assertNotNull("Derived source should not be null", source);
+        // In Update, it will be stored as it is in translog, which is in string representation
+        assertEquals(Geohash.stringEncode(40.33, 75.98), source.get("geopoint_field"));
+        assertEquals(1, source.get("numeric_field"));
+        assertEquals("initial", source.get("keyword_field"));
+        assertEquals(true, source.get("bool_field"));
+        assertEquals("initial text", source.get("text_field"));
+
+        GetResponse getResponse = client().prepareGet("test_derive", "1").get();
+        assertTrue(getResponse.isExists());
+        source = getResponse.getSourceAsMap();
+        assertNotNull("Derived source should not be null", source);
+        // In Update, it will be stored as it is in translog, which is in string representation, so in get call we are
+        // creating an in-memory lucene index, which will give the response in desired representation of lat/lon pair
+        Map<String, Object> latLon = (Map<String, Object>) source.get("geopoint_field");
+        assertEquals(75.98, (Double) latLon.get("lat"), 0.001);
+        assertEquals(40.33, (Double) latLon.get("lon"), 0.001);
+        assertEquals(1, source.get("numeric_field"));
+        assertEquals("initial", source.get("keyword_field"));
+        assertEquals(true, source.get("bool_field"));
+        assertEquals("initial text", source.get("text_field"));
+
+        // Test 2: Update existing document with script
+        updateResponse = client().prepareUpdate("test_derive", "1")
+            .setScript(
+                new Script(ScriptType.INLINE, UPDATE_SCRIPTS, PUT_VALUES_SCRIPT, Map.of("numeric_field", 2, "keyword_field", "updated"))
+            )
+            .setFetchSource(true)
+            .execute()
+            .actionGet();
+
+        assertThat(updateResponse.status(), equalTo(RestStatus.OK));
+        source = updateResponse.getGetResult().sourceAsMap();
+        assertNotNull("Derived source should not be null", source);
+        assertEquals(2, source.get("numeric_field"));
+        assertEquals("updated", source.get("keyword_field"));
+        assertEquals(true, source.get("bool_field")); // Unchanged
+        assertEquals("initial text", source.get("text_field")); // Unchanged
+
+        // Test 3: Update with doc
+        updateResponse = client().prepareUpdate("test_derive", "1")
+            .setDoc(jsonBuilder().startObject().field("bool_field", false).field("text_field", "updated text").endObject())
+            .setFetchSource(true)
+            .execute()
+            .actionGet();
+
+        assertThat(updateResponse.status(), equalTo(RestStatus.OK));
+        source = updateResponse.getGetResult().sourceAsMap();
+        assertNotNull("Derived source should not be null", source);
+        assertEquals(2, source.get("numeric_field")); // Unchanged
+        assertEquals("updated", source.get("keyword_field")); // Unchanged
+        assertEquals(false, source.get("bool_field"));
+        assertEquals("updated text", source.get("text_field"));
+
+        // Test 4: DocAsUpsert with non-existent document
+        updateResponse = client().prepareUpdate("test_derive", "2")
+            .setDoc(
+                jsonBuilder().startObject()
+                    .field("numeric_field", 5)
+                    .field("keyword_field", "doc_as_upsert")
+                    .field("bool_field", true)
+                    .field("text_field", "new document")
+                    .field("geopoint_field", Geohash.stringEncode(1.1, 1.2))
+                    .endObject()
+            )
+            .setDocAsUpsert(true)
+            .setFetchSource(true)
+            .execute()
+            .actionGet();
+
+        assertThat(updateResponse.status(), equalTo(RestStatus.CREATED));
+        source = updateResponse.getGetResult().sourceAsMap();
+        assertNotNull("Derived source should not be null", source);
+        assertEquals(5, source.get("numeric_field"));
+        assertEquals("doc_as_upsert", source.get("keyword_field"));
+        assertEquals(true, source.get("bool_field"));
+        assertEquals("new document", source.get("text_field"));
+        assertEquals(Geohash.stringEncode(1.1, 1.2), source.get("geopoint_field"));
+
+        getResponse = client().prepareGet("test_derive", "2").get();
+        assertTrue(getResponse.isExists());
+        source = getResponse.getSourceAsMap();
+        assertNotNull("Derived source should not be null", source);
+        assertEquals(5, source.get("numeric_field"));
+        assertEquals("doc_as_upsert", source.get("keyword_field"));
+        assertEquals(true, source.get("bool_field"));
+        assertEquals("new document", source.get("text_field"));
+        latLon = (Map<String, Object>) source.get("geopoint_field");
+        assertEquals(1.2, (Double) latLon.get("lat"), 0.001);
+        assertEquals(1.1, (Double) latLon.get("lon"), 0.001);
+
+        // Test 5: Scripted upsert
+        Map<String, Object> params = new HashMap<>();
+        params.put("numeric_field", 10);
+        params.put("keyword_field", "scripted_upsert");
+
+        updateResponse = client().prepareUpdate("test_derive", "3")
+            .setScript(new Script(ScriptType.INLINE, UPDATE_SCRIPTS, PUT_VALUES_SCRIPT, params))
+            .setUpsert(
+                jsonBuilder().startObject()
+                    .field("numeric_field", 0)
+                    .field("keyword_field", "initial")
+                    .field("bool_field", true)
+                    .endObject()
+            )
+            .setScriptedUpsert(true)
+            .setFetchSource(true)
+            .execute()
+            .actionGet();
+
+        assertThat(updateResponse.status(), equalTo(RestStatus.CREATED));
+        source = updateResponse.getGetResult().sourceAsMap();
+        assertNotNull("Derived source should not be null", source);
+        assertEquals(10, source.get("numeric_field"));
+        assertEquals("scripted_upsert", source.get("keyword_field"));
+        assertEquals(true, source.get("bool_field"));
+
+        // Test 6: Partial update with source filtering
+        updateResponse = client().prepareUpdate("test_derive", "1")
+            .setDoc(jsonBuilder().startObject().field("numeric_field", 15).field("keyword_field", "filtered").endObject())
+            .setFetchSource(new String[] { "numeric_field", "keyword_field" }, null)
+            .execute()
+            .actionGet();
+
+        assertThat(updateResponse.status(), equalTo(RestStatus.OK));
+        source = updateResponse.getGetResult().sourceAsMap();
+        assertNotNull("Derived source should not be null", source);
+        assertEquals(15, source.get("numeric_field"));
+        assertEquals("filtered", source.get("keyword_field"));
+        assertEquals(2, source.size()); // Only requested fields should be present
     }
 
     private static String indexOrAlias() {

--- a/server/src/internalClusterTest/java/org/opensearch/update/UpdateIT.java
+++ b/server/src/internalClusterTest/java/org/opensearch/update/UpdateIT.java
@@ -901,21 +901,21 @@ public class UpdateIT extends OpenSearchIntegTestCase {
     }
 
     public void testDerivedSourceWithUpdates() throws Exception {
-        // Create index with _source option set to derived
+        // Create index with derived source setting enabled
         String createIndexSource = """
             {
                 "settings": {
                     "index": {
                         "number_of_shards": 2,
                         "number_of_replicas": 0,
-                        "refresh_interval": -1
+                        "refresh_interval": -1,
+                        "derived_source": {
+                            "enabled": true
+                        }
                     }
                 },
                 "mappings": {
                     "_doc": {
-                        "_source": {
-                            "enabled": "derived"
-                        },
                         "properties": {
                             "geopoint_field": {
                                 "type": "geo_point"

--- a/server/src/main/java/org/opensearch/common/lucene/index/DerivedSourceDirectoryReader.java
+++ b/server/src/main/java/org/opensearch/common/lucene/index/DerivedSourceDirectoryReader.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.lucene.index;
+
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.FilterDirectoryReader;
+import org.apache.lucene.index.LeafReader;
+import org.opensearch.common.CheckedBiFunction;
+import org.opensearch.core.common.bytes.BytesReference;
+
+import java.io.IOException;
+
+/**
+ * {@link FilterDirectoryReader} that supports deriving source from lucene fields instead of directly reading from _source
+ * field.
+ *
+ * @opensearch.internal
+ */
+public class DerivedSourceDirectoryReader extends FilterDirectoryReader {
+    private final CheckedBiFunction<LeafReader, Integer, BytesReference, IOException> sourceProvider;
+    private final FilterDirectoryReader.SubReaderWrapper wrapper;
+
+    private DerivedSourceDirectoryReader(
+        DirectoryReader in,
+        FilterDirectoryReader.SubReaderWrapper wrapper,
+        CheckedBiFunction<LeafReader, Integer, BytesReference, IOException> sourceProvider
+    ) throws IOException {
+        super(in, wrapper);
+        this.wrapper = wrapper;
+        this.sourceProvider = sourceProvider;
+    }
+
+    @Override
+    protected DirectoryReader doWrapDirectoryReader(DirectoryReader directoryReader) throws IOException {
+        return new DerivedSourceDirectoryReader(in, wrapper, sourceProvider);
+    }
+
+    @Override
+    public CacheHelper getReaderCacheHelper() {
+        return in.getReaderCacheHelper();
+    }
+
+    public static DerivedSourceDirectoryReader wrap(
+        DirectoryReader in,
+        CheckedBiFunction<LeafReader, Integer, BytesReference, IOException> sourceProvider
+    ) throws IOException {
+        return new DerivedSourceDirectoryReader(in, new SubReaderWrapper() {
+            @Override
+            public LeafReader wrap(LeafReader reader) {
+                return new DerivedSourceLeafReader(reader, docID -> sourceProvider.apply(reader, docID));
+            }
+        }, sourceProvider);
+    }
+}

--- a/server/src/main/java/org/opensearch/common/lucene/index/DerivedSourceLeafReader.java
+++ b/server/src/main/java/org/opensearch/common/lucene/index/DerivedSourceLeafReader.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.lucene.index;
+
+import org.apache.lucene.codecs.StoredFieldsReader;
+import org.apache.lucene.index.CodecReader;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.StoredFields;
+import org.opensearch.common.CheckedFunction;
+import org.opensearch.core.common.bytes.BytesReference;
+
+import java.io.IOException;
+
+/**
+ * Wraps a {@link LeafReader} and provides access to the derived source.
+ *
+ * @opensearch.internal
+ */
+public class DerivedSourceLeafReader extends SequentialStoredFieldsLeafReader {
+
+    private final CheckedFunction<Integer, BytesReference, IOException> sourceProvider;
+
+    public DerivedSourceLeafReader(LeafReader in, CheckedFunction<Integer, BytesReference, IOException> sourceProvider) {
+        super(in);
+        this.sourceProvider = sourceProvider;
+    }
+
+    @Override
+    protected StoredFieldsReader doGetSequentialStoredFieldsReader(StoredFieldsReader reader) {
+        return reader;
+    }
+
+    @Override
+    public CacheHelper getCoreCacheHelper() {
+        return in.getCoreCacheHelper();
+    }
+
+    @Override
+    public CacheHelper getReaderCacheHelper() {
+        return in.getReaderCacheHelper();
+    }
+
+    @Override
+    public StoredFields storedFields() throws IOException {
+        return new DerivedSourceStoredFieldsReader.DerivedSourceStoredFields(in.storedFields(), sourceProvider);
+    }
+
+    @Override
+    public StoredFieldsReader getSequentialStoredFieldsReader() throws IOException {
+        if (in instanceof CodecReader) {
+            final CodecReader reader = (CodecReader) in;
+            final StoredFieldsReader sequentialReader = reader.getFieldsReader().getMergeInstance();
+            return doGetSequentialStoredFieldsReader(new DerivedSourceStoredFieldsReader(sequentialReader, sourceProvider));
+        } else if (in instanceof SequentialStoredFieldsLeafReader) {
+            final SequentialStoredFieldsLeafReader reader = (SequentialStoredFieldsLeafReader) in;
+            final StoredFieldsReader sequentialReader = reader.getSequentialStoredFieldsReader();
+            return doGetSequentialStoredFieldsReader(new DerivedSourceStoredFieldsReader(sequentialReader, sourceProvider));
+        } else {
+            throw new IOException("requires a CodecReader or a SequentialStoredFieldsLeafReader, got " + in.getClass());
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/common/lucene/index/DerivedSourceStoredFieldsReader.java
+++ b/server/src/main/java/org/opensearch/common/lucene/index/DerivedSourceStoredFieldsReader.java
@@ -1,0 +1,111 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.lucene.index;
+
+import org.apache.lucene.codecs.StoredFieldsReader;
+import org.apache.lucene.index.DocValuesSkipIndexType;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.StoredFieldVisitor;
+import org.apache.lucene.index.StoredFields;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.opensearch.common.CheckedFunction;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.index.mapper.SourceFieldMapper;
+
+import java.io.IOException;
+import java.util.Collections;
+
+/**
+ * A {@link StoredFieldsReader} that injects the _source field by using {@link DerivedSourceStoredFields}, which dynamically
+ * derives the source.
+ */
+public class DerivedSourceStoredFieldsReader extends StoredFieldsReader {
+
+    private final StoredFieldsReader delegate;
+    private final CheckedFunction<Integer, BytesReference, IOException> sourceProvider;
+    private final DerivedSourceStoredFields storedFields;
+
+    DerivedSourceStoredFieldsReader(StoredFieldsReader in, CheckedFunction<Integer, BytesReference, IOException> sourceProvider) {
+        this.delegate = in;
+        this.sourceProvider = sourceProvider;
+        this.storedFields = new DerivedSourceStoredFields(in, sourceProvider);
+    }
+
+    @Override
+    public StoredFieldsReader clone() {
+        return new DerivedSourceStoredFieldsReader(delegate.clone(), sourceProvider);
+    }
+
+    @Override
+    public void checkIntegrity() throws IOException {
+        delegate.checkIntegrity();
+    }
+
+    @Override
+    public void close() throws IOException {
+        delegate.close();
+    }
+
+    @Override
+    public StoredFieldsReader getMergeInstance() {
+        return delegate.getMergeInstance();
+    }
+
+    @Override
+    public void document(int docId, StoredFieldVisitor visitor) throws IOException {
+        storedFields.document(docId, visitor);
+    }
+
+    /**
+     * A {@link StoredFields} that injects a _source field into the stored fields after deriving it.
+     *
+     * @opensearch.internal
+     */
+    public static class DerivedSourceStoredFields extends StoredFields {
+        private static final FieldInfo FAKE_SOURCE_FIELD = new FieldInfo(
+            SourceFieldMapper.NAME,
+            1,
+            false,
+            false,
+            false,
+            IndexOptions.NONE,
+            DocValuesType.NONE,
+            DocValuesSkipIndexType.NONE,
+            -1,
+            Collections.emptyMap(),
+            0,
+            0,
+            0,
+            0,
+            VectorEncoding.FLOAT32,
+            VectorSimilarityFunction.EUCLIDEAN,
+            false,
+            false
+        );
+
+        private final CheckedFunction<Integer, BytesReference, IOException> sourceProvider;
+        private final StoredFields delegate;
+
+        public DerivedSourceStoredFields(StoredFields in, CheckedFunction<Integer, BytesReference, IOException> sourceProvider) {
+            this.delegate = in;
+            this.sourceProvider = sourceProvider;
+        }
+
+        @Override
+        public void document(int docId, StoredFieldVisitor visitor) throws IOException {
+            if (visitor.needsField(FAKE_SOURCE_FIELD) == StoredFieldVisitor.Status.YES) {
+                visitor.binaryField(FAKE_SOURCE_FIELD, sourceProvider.apply(docId).toBytesRef().bytes);
+            }
+            delegate.document(docId, visitor);
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/IndexScopedSettings.java
@@ -268,6 +268,9 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
                 IndexMetadata.INGESTION_SOURCE_PARAMS_SETTING,
                 IndexMetadata.INGESTION_SOURCE_ERROR_STRATEGY_SETTING,
 
+                // Setting for derived source feature
+                IndexSettings.INDEX_DERIVED_SOURCE_SETTING,
+
                 // validate that built-in similarities don't get redefined
                 Setting.groupSetting("index.similarity.", (s) -> {
                     Map<String, Settings> groups = s.getAsGroups();

--- a/server/src/main/java/org/opensearch/index/IndexSettings.java
+++ b/server/src/main/java/org/opensearch/index/IndexSettings.java
@@ -782,6 +782,12 @@ public final class IndexSettings {
         Property.IndexScope
     );
 
+    public static final Setting<Boolean> INDEX_DERIVED_SOURCE_SETTING = Setting.boolSetting(
+        "index.derived_source.enabled",
+        false,
+        Property.IndexScope
+    );
+
     private final Index index;
     private final Version version;
     private final Logger logger;
@@ -831,6 +837,7 @@ public final class IndexSettings {
     private final RemoteStorePathStrategy remoteStorePathStrategy;
     private final boolean isTranslogMetadataEnabled;
     private volatile boolean allowDerivedField;
+    private final boolean derivedSourceEnabled;
 
     /**
      * The maximum age of a retention lease before it is considered expired.
@@ -1063,6 +1070,7 @@ public final class IndexSettings {
         setMergeOnFlushPolicy(scopedSettings.get(INDEX_MERGE_ON_FLUSH_POLICY));
         checkPendingFlushEnabled = scopedSettings.get(INDEX_CHECK_PENDING_FLUSH_ENABLED);
         defaultSearchPipeline = scopedSettings.get(DEFAULT_SEARCH_PIPELINE);
+        derivedSourceEnabled = scopedSettings.get(INDEX_DERIVED_SOURCE_SETTING);
         /* There was unintentional breaking change got introduced with [OpenSearch-6424](https://github.com/opensearch-project/OpenSearch/pull/6424) (version 2.7).
          * For indices created prior version (prior to 2.7) which has IndexSort type, they used to type cast the SortField.Type
          * to higher bytes size like integer to long. This behavior was changed from OpenSearch 2.7 version not to
@@ -2033,5 +2041,9 @@ public final class IndexSettings {
 
     public void setRemoteStoreTranslogRepository(String remoteStoreTranslogRepository) {
         this.remoteStoreTranslogRepository = remoteStoreTranslogRepository;
+    }
+
+    public boolean isDerivedSourceEnabled() {
+        return derivedSourceEnabled;
     }
 }

--- a/server/src/main/java/org/opensearch/index/engine/Engine.java
+++ b/server/src/main/java/org/opensearch/index/engine/Engine.java
@@ -80,6 +80,7 @@ import org.opensearch.core.common.unit.ByteSizeValue;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.VersionType;
 import org.opensearch.index.mapper.IdFieldMapper;
+import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.Mapping;
 import org.opensearch.index.mapper.ParseContext.Document;
 import org.opensearch.index.mapper.ParsedDocument;
@@ -736,7 +737,8 @@ public abstract class Engine implements LifecycleAware, Closeable {
         }
     }
 
-    public abstract GetResult get(Get get, BiFunction<String, SearcherScope, Searcher> searcherFactory) throws EngineException;
+    public abstract GetResult get(Get get, MapperService mapperService, BiFunction<String, SearcherScope, Searcher> searcherFactory)
+        throws EngineException;
 
     /**
      * Acquires a point-in-time reader that can be used to create {@link Engine.Searcher}s on demand.

--- a/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/IngestionEngine.java
@@ -21,6 +21,7 @@ import org.opensearch.index.IngestionShardConsumer;
 import org.opensearch.index.IngestionShardPointer;
 import org.opensearch.index.mapper.DocumentMapperForType;
 import org.opensearch.index.mapper.IdFieldMapper;
+import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.ParseContext;
 import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.index.translog.NoOpTranslogManager;
@@ -179,7 +180,8 @@ public class IngestionEngine extends InternalEngine {
     }
 
     @Override
-    public GetResult get(Get get, BiFunction<String, SearcherScope, Searcher> searcherFactory) throws EngineException {
+    public GetResult get(Get get, MapperService mapperService, BiFunction<String, SearcherScope, Searcher> searcherFactory)
+        throws EngineException {
         return getFromSearcher(get, searcherFactory, SearcherScope.EXTERNAL);
     }
 

--- a/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/InternalEngine.java
@@ -93,6 +93,7 @@ import org.opensearch.index.IndexSettings;
 import org.opensearch.index.VersionType;
 import org.opensearch.index.fieldvisitor.IdOnlyFieldVisitor;
 import org.opensearch.index.mapper.IdFieldMapper;
+import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.ParseContext;
 import org.opensearch.index.mapper.ParsedDocument;
 import org.opensearch.index.mapper.SeqNoFieldMapper;
@@ -598,7 +599,8 @@ public class InternalEngine extends Engine {
     }
 
     @Override
-    public GetResult get(Get get, BiFunction<String, SearcherScope, Engine.Searcher> searcherFactory) throws EngineException {
+    public GetResult get(Get get, MapperService mapperService, BiFunction<String, SearcherScope, Engine.Searcher> searcherFactory)
+        throws EngineException {
         assert Objects.equals(get.uid().field(), IdFieldMapper.NAME) : get.uid().field();
         try (ReleasableLock ignored = readLock.acquire()) {
             ensureOpen();
@@ -640,7 +642,7 @@ public class InternalEngine extends Engine {
                                 if (operation != null) {
                                     // in the case of a already pruned translog generation we might get null here - yet very unlikely
                                     final Translog.Index index = (Translog.Index) operation;
-                                    TranslogLeafReader reader = new TranslogLeafReader(index);
+                                    TranslogLeafReader reader = new TranslogLeafReader(index, mapperService, config());
                                     return new GetResult(
                                         new Engine.Searcher(
                                             "realtime_get",

--- a/server/src/main/java/org/opensearch/index/engine/NRTReplicationEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/NRTReplicationEngine.java
@@ -21,6 +21,7 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.ReleasableLock;
 import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.core.common.unit.ByteSizeValue;
+import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.seqno.LocalCheckpointTracker;
 import org.opensearch.index.seqno.SeqNoStats;
 import org.opensearch.index.seqno.SequenceNumbers;
@@ -265,7 +266,8 @@ public class NRTReplicationEngine extends Engine {
     }
 
     @Override
-    public GetResult get(Get get, BiFunction<String, SearcherScope, Searcher> searcherFactory) throws EngineException {
+    public GetResult get(Get get, MapperService mapperService, BiFunction<String, SearcherScope, Searcher> searcherFactory)
+        throws EngineException {
         return getFromSearcher(get, searcherFactory, SearcherScope.EXTERNAL);
     }
 

--- a/server/src/main/java/org/opensearch/index/engine/ReadOnlyEngine.java
+++ b/server/src/main/java/org/opensearch/index/engine/ReadOnlyEngine.java
@@ -45,6 +45,7 @@ import org.opensearch.common.concurrent.GatedCloseable;
 import org.opensearch.common.lucene.Lucene;
 import org.opensearch.common.lucene.index.OpenSearchDirectoryReader;
 import org.opensearch.common.util.io.IOUtils;
+import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.seqno.SeqNoStats;
 import org.opensearch.index.seqno.SequenceNumbers;
 import org.opensearch.index.store.Store;
@@ -284,7 +285,8 @@ public class ReadOnlyEngine extends Engine {
     }
 
     @Override
-    public GetResult get(Get get, BiFunction<String, SearcherScope, Engine.Searcher> searcherFactory) throws EngineException {
+    public GetResult get(Get get, MapperService mapperService, BiFunction<String, SearcherScope, Engine.Searcher> searcherFactory)
+        throws EngineException {
         return getFromSearcher(get, searcherFactory, SearcherScope.EXTERNAL);
     }
 

--- a/server/src/main/java/org/opensearch/index/engine/TranslogLeafReader.java
+++ b/server/src/main/java/org/opensearch/index/engine/TranslogLeafReader.java
@@ -31,8 +31,10 @@
 
 package org.opensearch.index.engine;
 
+import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.DocValuesSkipIndexType;
 import org.apache.lucene.index.DocValuesSkipper;
 import org.apache.lucene.index.DocValuesType;
@@ -40,6 +42,8 @@ import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafMetaData;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.NumericDocValues;
@@ -54,18 +58,29 @@ import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.KnnCollector;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
+import org.opensearch.common.lucene.Lucene;
+import org.opensearch.common.lucene.index.SequentialStoredFieldsLeafReader;
+import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.common.util.set.Sets;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.index.mapper.IdFieldMapper;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.index.mapper.ParsedDocument;
 import org.opensearch.index.mapper.RoutingFieldMapper;
 import org.opensearch.index.mapper.SourceFieldMapper;
+import org.opensearch.index.mapper.SourceToParse;
 import org.opensearch.index.mapper.Uid;
 import org.opensearch.index.translog.Translog;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Set;
+
+import static org.apache.lucene.index.DirectoryReader.open;
 
 /**
  * Internal class that mocks a single doc read from the transaction log as a leaf reader.
@@ -75,6 +90,9 @@ import java.util.Set;
 public final class TranslogLeafReader extends LeafReader {
 
     private final Translog.Index operation;
+    private final MapperService mapperService;
+    private final EngineConfig engineConfig;
+    private volatile LeafReader inMemoryIndexReader;
     private static final FieldInfo FAKE_SOURCE_FIELD = new FieldInfo(
         SourceFieldMapper.NAME,
         1,
@@ -137,8 +155,90 @@ public final class TranslogLeafReader extends LeafReader {
     );
     public static Set<String> ALL_FIELD_NAMES = Sets.newHashSet(FAKE_SOURCE_FIELD.name, FAKE_ROUTING_FIELD.name, FAKE_ID_FIELD.name);
 
-    TranslogLeafReader(Translog.Index operation) {
+    TranslogLeafReader(Translog.Index operation, MapperService mapperService, EngineConfig engineConfig) {
         this.operation = operation;
+        this.mapperService = mapperService;
+        this.engineConfig = engineConfig;
+    }
+
+    private LeafReader getInMemoryIndexReader() throws IOException {
+        if (inMemoryIndexReader == null) {
+            synchronized (this) {
+                if (inMemoryIndexReader == null) {
+                    inMemoryIndexReader = createInMemoryIndexReader(operation, mapperService, engineConfig);
+                }
+            }
+        }
+        return inMemoryIndexReader;
+    }
+
+    public static LeafReader createInMemoryIndexReader(Translog.Index operation, MapperService mapperService, EngineConfig engineConfig)
+        throws IOException {
+        boolean success = false;
+        final Directory directory = new ByteBuffersDirectory();
+        try {
+            SourceToParse sourceToParse = new SourceToParse(
+                mapperService.index().getName(),
+                operation.id(),
+                operation.source(),
+                MediaTypeRegistry.xContentType(operation.source()),
+                operation.routing()
+            );
+            ParsedDocument parsedDocument = mapperService.documentMapper().parse(sourceToParse);
+            parsedDocument.updateSeqID(operation.seqNo(), operation.primaryTerm());
+            parsedDocument.version().setLongValue(operation.version());
+            final IndexWriterConfig iwc = new IndexWriterConfig(engineConfig.getAnalyzer());
+            iwc.setOpenMode(IndexWriterConfig.OpenMode.CREATE);
+            iwc.setCodec(engineConfig.getCodec());
+            IndexWriter indexWriter = new IndexWriter(directory, iwc);
+            indexWriter.addDocuments(parsedDocument.docs());
+            final DirectoryReader directoryReader = open(indexWriter);
+            if (directoryReader.leaves().size() != 1
+                || directoryReader.leaves().get(0).reader().numDocs() != parsedDocument.docs().size()) {
+                throw new IllegalStateException(
+                    "Expected a single segment with "
+                        + parsedDocument.docs().size()
+                        + " documents, but ["
+                        + directoryReader.leaves().size()
+                        + " segments with "
+                        + directoryReader.leaves().get(0).reader().numDocs()
+                        + " documents"
+                );
+            }
+            LeafReader leafReader = directoryReader.leaves().get(0).reader();
+            LeafReader sequentialLeafReader = new SequentialStoredFieldsLeafReader(leafReader) {
+                @Override
+                protected void doClose() throws IOException {
+                    IOUtils.close(super::doClose, directory);
+                }
+
+                @Override
+                public CacheHelper getCoreCacheHelper() {
+                    return leafReader.getCoreCacheHelper();
+                }
+
+                @Override
+                public CacheHelper getReaderCacheHelper() {
+                    return leafReader.getReaderCacheHelper();
+                }
+
+                @Override
+                public StoredFieldsReader getSequentialStoredFieldsReader() {
+                    return Lucene.segmentReader(leafReader).getFieldsReader().getMergeInstance();
+                }
+
+                @Override
+                protected StoredFieldsReader doGetSequentialStoredFieldsReader(StoredFieldsReader reader) {
+                    return reader;
+                }
+            };
+            success = true;
+            return sequentialLeafReader;
+        } finally {
+            if (!success) {
+                IOUtils.closeWhileHandlingException(directory);
+            }
+        }
     }
 
     @Override
@@ -230,9 +330,18 @@ public final class TranslogLeafReader extends LeafReader {
                     throw new IllegalArgumentException("no such doc ID " + docID);
                 }
                 if (visitor.needsField(FAKE_SOURCE_FIELD) == StoredFieldVisitor.Status.YES) {
-                    assert operation.source().toBytesRef().offset == 0;
-                    assert operation.source().toBytesRef().length == operation.source().toBytesRef().bytes.length;
-                    visitor.binaryField(FAKE_SOURCE_FIELD, operation.source().toBytesRef().bytes);
+                    if (mapperService.isDerivedSourceEnabled()) {
+                        LeafReader leafReader = getInMemoryIndexReader();
+                        assert leafReader != null && leafReader.leaves().size() == 1;
+                        visitor.binaryField(
+                            FAKE_SOURCE_FIELD,
+                            mapperService.documentMapper().root().deriveSource(leafReader, docID).toBytesRef().bytes
+                        );
+                    } else {
+                        assert operation.source().toBytesRef().offset == 0;
+                        assert operation.source().toBytesRef().length == operation.source().toBytesRef().bytes.length;
+                        visitor.binaryField(FAKE_SOURCE_FIELD, operation.source().toBytesRef().bytes);
+                    }
                 }
                 if (operation.routing() != null && visitor.needsField(FAKE_ROUTING_FIELD) == StoredFieldVisitor.Status.YES) {
                     visitor.stringField(FAKE_ROUTING_FIELD, operation.routing());

--- a/server/src/main/java/org/opensearch/index/engine/TranslogLeafReader.java
+++ b/server/src/main/java/org/opensearch/index/engine/TranslogLeafReader.java
@@ -330,7 +330,7 @@ public final class TranslogLeafReader extends LeafReader {
                     throw new IllegalArgumentException("no such doc ID " + docID);
                 }
                 if (visitor.needsField(FAKE_SOURCE_FIELD) == StoredFieldVisitor.Status.YES) {
-                    if (mapperService.isDerivedSourceEnabled()) {
+                    if (mapperService.getIndexSettings().isDerivedSourceEnabled()) {
                         LeafReader leafReader = getInMemoryIndexReader();
                         assert leafReader != null && leafReader.leaves().size() == 1;
                         visitor.binaryField(

--- a/server/src/main/java/org/opensearch/index/fieldvisitor/SingleFieldsVisitor.java
+++ b/server/src/main/java/org/opensearch/index/fieldvisitor/SingleFieldsVisitor.java
@@ -71,6 +71,10 @@ public final class SingleFieldsVisitor extends StoredFieldVisitor {
         return Status.NO;
     }
 
+    public void reset() {
+        destination.clear();
+    }
+
     private void addValue(Object value) {
         destination.add(field.valueForDisplay(value));
     }

--- a/server/src/main/java/org/opensearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DocumentMapper.java
@@ -218,10 +218,6 @@ public class DocumentMapper implements ToXContentFragment {
         return metadataMapper(SourceFieldMapper.class);
     }
 
-    public boolean isDerivedSourceEnabled() {
-        return sourceMapper().isDerivedSourceEnabled();
-    }
-
     public IdFieldMapper idFieldMapper() {
         return metadataMapper(IdFieldMapper.class);
     }

--- a/server/src/main/java/org/opensearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DocumentMapper.java
@@ -218,6 +218,10 @@ public class DocumentMapper implements ToXContentFragment {
         return metadataMapper(SourceFieldMapper.class);
     }
 
+    public boolean isDerivedSourceEnabled() {
+        return sourceMapper().isDerivedSourceEnabled();
+    }
+
     public IdFieldMapper idFieldMapper() {
         return metadataMapper(IdFieldMapper.class);
     }

--- a/server/src/main/java/org/opensearch/index/mapper/DocumentMapperParser.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DocumentMapperParser.java
@@ -172,7 +172,11 @@ public class DocumentMapperParser {
 
         checkNoRemainingFields(mapping, parserContext.indexVersionCreated(), "Root mapping definition has unsupported parameters: ");
 
-        return docBuilder.build(mapperService);
+        final DocumentMapper documentMapper = docBuilder.build(mapperService);
+        if (documentMapper.isDerivedSourceEnabled()) {
+            documentMapper.root().canDeriveSource();
+        }
+        return documentMapper;
     }
 
     public static void checkNoRemainingFields(String fieldName, Map<?, ?> fieldNodeMap, Version indexVersionCreated) {

--- a/server/src/main/java/org/opensearch/index/mapper/DocumentMapperParser.java
+++ b/server/src/main/java/org/opensearch/index/mapper/DocumentMapperParser.java
@@ -173,7 +173,7 @@ public class DocumentMapperParser {
         checkNoRemainingFields(mapping, parserContext.indexVersionCreated(), "Root mapping definition has unsupported parameters: ");
 
         final DocumentMapper documentMapper = docBuilder.build(mapperService);
-        if (documentMapper.isDerivedSourceEnabled()) {
+        if (mapperService.getIndexSettings().isDerivedSourceEnabled()) {
             documentMapper.root().canDeriveSource();
         }
         return documentMapper;

--- a/server/src/main/java/org/opensearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/FieldMapper.java
@@ -589,6 +589,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
     /**
      * Method to determine, if it is possible to derive source for this field using field mapping parameters
      */
+    @Override
     public void canDeriveSource() {
         if (this.copyTo() != null && !this.copyTo().copyToFields().isEmpty()) {
             throw new UnsupportedOperationException("Unable to derive source for fields with copy_to parameter set");
@@ -617,6 +618,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
      * @param leafReader - leafReader to read data from
      * @param docId - docId for which we want to derive the source
      */
+    @Override
     public void deriveSource(XContentBuilder builder, LeafReader leafReader, int docId) throws IOException {
         derivedFieldGenerator.generate(builder, leafReader, docId);
     }

--- a/server/src/main/java/org/opensearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/Mapper.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.index.mapper;
 
+import org.apache.lucene.index.LeafReader;
 import org.opensearch.Version;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.Nullable;
@@ -39,11 +40,13 @@ import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.time.DateFormatter;
 import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.analysis.IndexAnalyzers;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.similarity.SimilarityProvider;
 import org.opensearch.script.ScriptService;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
@@ -298,5 +301,22 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
      */
     protected static boolean hasIndexCreated(Settings settings) {
         return settings.hasValue(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey());
+    }
+
+    /**
+     * Method to determine, if it is possible to derive source for this field using field mapping parameters
+     */
+    public void canDeriveSource() {
+        throw new UnsupportedOperationException("Derived source field is not supported for [" + name() + "] field");
+    }
+
+    /**
+     * Method used for deriving source and building it to XContentBuilder object
+     * @param builder - builder to store the derived source filed
+     * @param leafReader - leafReader to read data from
+     * @param docId - docId for which we want to derive the source
+     */
+    public void deriveSource(XContentBuilder builder, LeafReader leafReader, int docId) throws IOException {
+        throw new UnsupportedOperationException("Derived source field is not supported for [" + name() + "] field");
     }
 }

--- a/server/src/main/java/org/opensearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/opensearch/index/mapper/MapperService.java
@@ -786,10 +786,6 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         return Collections.unmodifiableSet(mapperRegistry.getMetadataMapperParsers().keySet());
     }
 
-    public boolean isDerivedSourceEnabled() {
-        return documentMapper() != null && documentMapper().isDerivedSourceEnabled();
-    }
-
     /**
      * An analyzer wrapper that can lookup fields within the index mappings
      */

--- a/server/src/main/java/org/opensearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/opensearch/index/mapper/MapperService.java
@@ -786,6 +786,10 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         return Collections.unmodifiableSet(mapperRegistry.getMetadataMapperParsers().keySet());
     }
 
+    public boolean isDerivedSourceEnabled() {
+        return documentMapper() != null && documentMapper().isDerivedSourceEnabled();
+    }
+
     /**
      * An analyzer wrapper that can lookup fields within the index mappings
      */

--- a/server/src/main/java/org/opensearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ObjectMapper.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.index.mapper;
 
+import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.search.Query;
 import org.opensearch.OpenSearchParseException;
 import org.opensearch.Version;
@@ -911,4 +912,22 @@ public class ObjectMapper extends Mapper implements Cloneable {
 
     }
 
+    @Override
+    public void canDeriveSource() {
+        if (!this.enabled.value() || this.nested.isNested()) {
+            throw new UnsupportedOperationException("Derived source is not supported for " + name() + " field as it is disabled/nested");
+        }
+        for (final Mapper mapper : this.mappers.values()) {
+            mapper.canDeriveSource();
+        }
+    }
+
+    @Override
+    public void deriveSource(XContentBuilder builder, LeafReader leafReader, int docId) throws IOException {
+        builder.startObject(simpleName());
+        for (final Mapper mapper : this.mappers.values()) {
+            mapper.deriveSource(builder, leafReader, docId);
+        }
+        builder.endObject();
+    }
 }

--- a/server/src/main/java/org/opensearch/index/mapper/ParametrizedFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ParametrizedFieldMapper.java
@@ -552,24 +552,6 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
         public static Parameter<Float> boostParam() {
             return Parameter.floatParam("boost", true, m -> m.fieldType().boost(), 1.0f);
         }
-
-        /**
-         * Defines a parameter that takes the parameter for source option field and converts it to
-         * {@link SourceFieldMapper.SourceOptions}
-         * @param name          the parameter name
-         * @param initializer   a function that reads the parameter value from an existing mapper
-         * @param defaultValue  default value of the parameter
-         */
-        public static Parameter<SourceFieldMapper.SourceOptions> sourceOptionParam(
-            String name,
-            Function<FieldMapper, SourceFieldMapper.SourceOptions> initializer,
-            SourceFieldMapper.SourceOptions defaultValue
-        ) {
-            return new Parameter<>(name, false, () -> defaultValue, (n, c, o) -> {
-                String sourceOption = o.toString();
-                return SourceFieldMapper.SourceOptions.option(sourceOption);
-            }, initializer);
-        }
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/mapper/ParametrizedFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/ParametrizedFieldMapper.java
@@ -553,6 +553,23 @@ public abstract class ParametrizedFieldMapper extends FieldMapper {
             return Parameter.floatParam("boost", true, m -> m.fieldType().boost(), 1.0f);
         }
 
+        /**
+         * Defines a parameter that takes the parameter for source option field and converts it to
+         * {@link SourceFieldMapper.SourceOptions}
+         * @param name          the parameter name
+         * @param initializer   a function that reads the parameter value from an existing mapper
+         * @param defaultValue  default value of the parameter
+         */
+        public static Parameter<SourceFieldMapper.SourceOptions> sourceOptionParam(
+            String name,
+            Function<FieldMapper, SourceFieldMapper.SourceOptions> initializer,
+            SourceFieldMapper.SourceOptions defaultValue
+        ) {
+            return new Parameter<>(name, false, () -> defaultValue, (n, c, o) -> {
+                String sourceOption = o.toString();
+                return SourceFieldMapper.SourceOptions.option(sourceOption);
+            }, initializer);
+        }
     }
 
     /**

--- a/server/src/main/java/org/opensearch/index/mapper/SourceFieldMapper.java
+++ b/server/src/main/java/org/opensearch/index/mapper/SourceFieldMapper.java
@@ -39,7 +39,6 @@ import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
 import org.opensearch.common.Nullable;
-import org.opensearch.common.annotation.ExperimentalApi;
 import org.opensearch.common.annotation.PublicApi;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.io.stream.BytesStreamOutput;
@@ -96,44 +95,6 @@ public class SourceFieldMapper extends MetadataFieldMapper {
         }
     }
 
-    /**
-     * Represents whether the source is stored or not.
-     * If disabled, the source is not added to the document and is not retrievable.
-     * If enabled, the source is added to the document and will be directly used during source retrieval.
-     * If derived, the source is not added to the document and is retrieved from lucene data structures.
-     */
-    @ExperimentalApi
-    public enum SourceOptions {
-        ENABLED("true"),
-        DISABLED("false"),
-        DERIVED("derived");
-
-        private final String option;
-
-        SourceOptions(String option) {
-            this.option = option;
-        }
-
-        public String getOption() {
-            return option;
-        }
-
-        // We need to check Enum name as well as value because of the mapping merge that happens in which, option value
-        // will be represented as Enum name rather than value
-        public static SourceOptions option(String value) {
-            try {
-                return Enum.valueOf(SourceOptions.class, value);
-            } catch (IllegalArgumentException e) {
-                for (SourceOptions option : SourceOptions.values()) {
-                    if (option.getOption().equals(value)) {
-                        return option;
-                    }
-                }
-            }
-            throw new IllegalArgumentException("Invalid _source.enabled option supplied: " + value);
-        }
-    }
-
     private static SourceFieldMapper toType(FieldMapper in) {
         return (SourceFieldMapper) in;
     }
@@ -145,11 +106,7 @@ public class SourceFieldMapper extends MetadataFieldMapper {
      */
     public static class Builder extends MetadataFieldMapper.Builder {
 
-        private final Parameter<SourceOptions> enabled = Parameter.sourceOptionParam(
-            "enabled",
-            m -> toType(m).enabled,
-            SourceOptions.ENABLED
-        );
+        private final Parameter<Boolean> enabled = Parameter.boolParam("enabled", false, m -> toType(m).enabled, Defaults.ENABLED);
         private final Parameter<List<String>> includes = Parameter.stringArrayParam(
             "includes",
             false,
@@ -245,8 +202,8 @@ public class SourceFieldMapper extends MetadataFieldMapper {
      */
     static final class SourceFieldType extends MappedFieldType {
 
-        private SourceFieldType(SourceOptions enabled) {
-            super(NAME, false, SourceOptions.ENABLED.equals(enabled), false, TextSearchInfo.NONE, Collections.emptyMap());
+        private SourceFieldType(boolean enabled) {
+            super(NAME, false, enabled, false, TextSearchInfo.NONE, Collections.emptyMap());
         }
 
         @Override
@@ -270,7 +227,7 @@ public class SourceFieldMapper extends MetadataFieldMapper {
         }
     }
 
-    private final SourceOptions enabled;
+    private final boolean enabled;
     private final boolean recoverySourceEnabled;
     /** indicates whether the source will always exist and be complete, for use by features like the update API */
     private final boolean complete;
@@ -281,11 +238,11 @@ public class SourceFieldMapper extends MetadataFieldMapper {
     private final String[] recoverySourceExcludes;
 
     private SourceFieldMapper() {
-        this(SourceOptions.ENABLED, Strings.EMPTY_ARRAY, Strings.EMPTY_ARRAY, true, Strings.EMPTY_ARRAY, Strings.EMPTY_ARRAY);
+        this(Defaults.ENABLED, Strings.EMPTY_ARRAY, Strings.EMPTY_ARRAY, Defaults.ENABLED, Strings.EMPTY_ARRAY, Strings.EMPTY_ARRAY);
     }
 
     private SourceFieldMapper(
-        SourceOptions enabled,
+        boolean enabled,
         String[] includes,
         String[] excludes,
         boolean recoverySourceEnabled,
@@ -297,8 +254,8 @@ public class SourceFieldMapper extends MetadataFieldMapper {
         this.includes = includes;
         this.excludes = excludes;
         final boolean filtered = CollectionUtils.isEmpty(includes) == false || CollectionUtils.isEmpty(excludes) == false;
-        this.filter = !SourceOptions.DISABLED.equals(enabled) && filtered ? XContentMapValues.filter(includes, excludes) : null;
-        this.complete = !SourceOptions.DISABLED.equals(enabled) && CollectionUtils.isEmpty(includes) && CollectionUtils.isEmpty(excludes);
+        this.filter = enabled && filtered ? XContentMapValues.filter(includes, excludes) : null;
+        this.complete = enabled && CollectionUtils.isEmpty(includes) && CollectionUtils.isEmpty(excludes);
 
         // Set parameters for recovery source
         this.recoverySourceEnabled = recoverySourceEnabled;
@@ -312,11 +269,7 @@ public class SourceFieldMapper extends MetadataFieldMapper {
     }
 
     public boolean enabled() {
-        return SourceOptions.ENABLED.equals(enabled);
-    }
-
-    public boolean isDerivedSourceEnabled() {
-        return SourceOptions.DERIVED.equals(enabled);
+        return enabled;
     }
 
     public boolean isComplete() {
@@ -325,7 +278,7 @@ public class SourceFieldMapper extends MetadataFieldMapper {
 
     @Override
     public void preParse(ParseContext context) throws IOException {
-        if (isDerivedSourceEnabled()) {
+        if (context.indexSettings().isDerivedSourceEnabled()) {
             return;
         }
         BytesReference originalSource = context.sourceToParse().source();
@@ -355,7 +308,7 @@ public class SourceFieldMapper extends MetadataFieldMapper {
 
     @Nullable
     public BytesReference applyFilters(@Nullable BytesReference originalSource, @Nullable MediaType contentType) throws IOException {
-        return applyFilters(originalSource, contentType, !SourceOptions.DISABLED.equals(enabled), filter);
+        return applyFilters(originalSource, contentType, enabled, filter);
     }
 
     @Nullable

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -89,6 +89,7 @@ import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.lease.Releasable;
 import org.opensearch.common.lease.Releasables;
 import org.opensearch.common.lucene.Lucene;
+import org.opensearch.common.lucene.index.DerivedSourceDirectoryReader;
 import org.opensearch.common.lucene.index.OpenSearchDirectoryReader;
 import org.opensearch.common.metrics.CounterMetric;
 import org.opensearch.common.metrics.MeanMetric;
@@ -1407,7 +1408,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         if (mapper == null) {
             return GetResult.NOT_EXISTS;
         }
-        return getEngine().get(get, this::acquireSearcher);
+        return getEngine().get(get, mapperService, this::acquireSearcher);
     }
 
     /**
@@ -1974,6 +1975,15 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             : "DirectoryReader must be an instance or OpenSearchDirectoryReader";
         boolean success = false;
         try {
+            final CheckedFunction<DirectoryReader, DirectoryReader, IOException> readerWrapper;
+            if (mapperService.isDerivedSourceEnabled()) {
+                readerWrapper = reader -> {
+                    final DirectoryReader wrappedReader = this.readerWrapper == null ? reader : this.readerWrapper.apply(reader);
+                    return DerivedSourceDirectoryReader.wrap(wrappedReader, mapperService.documentMapper().root()::deriveSource);
+                };
+            } else {
+                readerWrapper = this.readerWrapper;
+            }
             final Engine.Searcher newSearcher = readerWrapper == null ? searcher : wrapSearcher(searcher, readerWrapper);
             assert newSearcher != null;
             success = true;

--- a/server/src/main/java/org/opensearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/opensearch/index/shard/IndexShard.java
@@ -483,7 +483,14 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             cachingPolicy = new UsageTrackingQueryCachingPolicy();
         }
         indexShardOperationPermits = new IndexShardOperationPermits(shardId, threadPool);
-        readerWrapper = indexReaderWrapper;
+        if (indexSettings.isDerivedSourceEnabled()) {
+            readerWrapper = reader -> {
+                final DirectoryReader wrappedReader = indexReaderWrapper == null ? reader : indexReaderWrapper.apply(reader);
+                return DerivedSourceDirectoryReader.wrap(wrappedReader, mapperService.documentMapper().root()::deriveSource);
+            };
+        } else {
+            readerWrapper = indexReaderWrapper;
+        }
         refreshListeners = buildRefreshListeners();
         lastSearcherAccess.set(threadPool.relativeTimeInMillis());
         persistMetadata(path, indexSettings, shardRouting, null, logger);
@@ -1975,15 +1982,6 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             : "DirectoryReader must be an instance or OpenSearchDirectoryReader";
         boolean success = false;
         try {
-            final CheckedFunction<DirectoryReader, DirectoryReader, IOException> readerWrapper;
-            if (mapperService.isDerivedSourceEnabled()) {
-                readerWrapper = reader -> {
-                    final DirectoryReader wrappedReader = this.readerWrapper == null ? reader : this.readerWrapper.apply(reader);
-                    return DerivedSourceDirectoryReader.wrap(wrappedReader, mapperService.documentMapper().root()::deriveSource);
-                };
-            } else {
-                readerWrapper = this.readerWrapper;
-            }
             final Engine.Searcher newSearcher = readerWrapper == null ? searcher : wrapSearcher(searcher, readerWrapper);
             assert newSearcher != null;
             success = true;

--- a/server/src/test/java/org/opensearch/common/lucene/index/DerivedSourceDirectoryReaderTests.java
+++ b/server/src/test/java/org/opensearch/common/lucene/index/DerivedSourceDirectoryReaderTests.java
@@ -1,0 +1,191 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.lucene.index;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NoMergePolicy;
+import org.apache.lucene.index.StoredFieldVisitor;
+import org.apache.lucene.index.StoredFields;
+import org.apache.lucene.store.Directory;
+import org.opensearch.common.CheckedBiFunction;
+import org.opensearch.common.util.io.IOUtils;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.test.OpenSearchTestCase;
+import org.junit.After;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class DerivedSourceDirectoryReaderTests extends OpenSearchTestCase {
+
+    private Directory dir;
+    private IndexWriter writer;
+    private DirectoryReader directoryReader;
+    private DerivedSourceDirectoryReader reader;
+    private static final byte[] TEST_SOURCE = "{\"field\":\"value\"}".getBytes(StandardCharsets.UTF_8);
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        dir = newDirectory();
+        IndexWriterConfig config = newIndexWriterConfig(random(), null);
+        writer = new IndexWriter(dir, config);
+
+        Document doc = new Document();
+        doc.add(new StoredField("_source", TEST_SOURCE));
+        writer.addDocument(doc);
+        writer.commit();
+
+        directoryReader = DirectoryReader.open(writer);
+        reader = DerivedSourceDirectoryReader.wrap(directoryReader, (leafReader, docId) -> new BytesArray(TEST_SOURCE));
+    }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        try {
+            IOUtils.close(reader, directoryReader, writer, dir);
+        } finally {
+            super.tearDown();
+        }
+    }
+
+    public void testWrap() throws IOException {
+        assertNotNull("Wrapped reader should not be null", reader);
+        List<LeafReaderContext> leaves = reader.leaves();
+        assertFalse("Should have at least one leaf", leaves.isEmpty());
+        assertTrue("Leaf should be DerivedSourceLeafReader", leaves.get(0).reader() instanceof DerivedSourceLeafReader);
+    }
+
+    public void testDoWrapDirectoryReader() throws IOException {
+        DirectoryReader wrapped = reader.doWrapDirectoryReader(directoryReader);
+        assertNotNull("Wrapped reader should not be null", wrapped);
+        assertTrue("Should be DerivedSourceDirectoryReader", wrapped instanceof DerivedSourceDirectoryReader);
+    }
+
+    public void testGetReaderCacheHelper() {
+        assertEquals("Cache helper should match input reader", directoryReader.getReaderCacheHelper(), reader.getReaderCacheHelper());
+    }
+
+    public void testSourceProviderCalls() throws IOException {
+        AtomicInteger sourceProviderCalls = new AtomicInteger(0);
+        Map<String, Integer> leafCalls = new HashMap<>();
+
+        CheckedBiFunction<LeafReader, Integer, BytesReference, IOException> countingSourceProvider = (leafReader, docId) -> {
+            sourceProviderCalls.incrementAndGet();
+            String leafKey = leafReader.toString();
+            leafCalls.merge(leafKey, 1, Integer::sum);
+            return new BytesArray(TEST_SOURCE);
+        };
+
+        DerivedSourceDirectoryReader countingReader = DerivedSourceDirectoryReader.wrap(directoryReader, countingSourceProvider);
+
+        // Access stored fields for all documents in all leaves
+        for (LeafReaderContext context : countingReader.leaves()) {
+            StoredFields storedFields = context.reader().storedFields();
+            for (int i = 0; i < context.reader().maxDoc(); i++) {
+                storedFields.document(i, new StoredFieldVisitor() {
+                    @Override
+                    public Status needsField(FieldInfo fieldInfo) {
+                        return fieldInfo.name.equals("_source") ? Status.YES : Status.NO;
+                    }
+                });
+            }
+        }
+
+        assertTrue("Source provider should be called", sourceProviderCalls.get() > 0);
+        assertFalse("Should have leaf calls recorded", leafCalls.isEmpty());
+    }
+
+    public void testWithMultipleSegments() throws IOException {
+        // Create index with multiple segments
+        Directory multiDir = newDirectory();
+        IndexWriterConfig config = newIndexWriterConfig(random(), null).setMaxBufferedDocs(2) // Force multiple segments
+            .setMergePolicy(NoMergePolicy.INSTANCE);
+        IndexWriter multiWriter = new IndexWriter(multiDir, config);
+
+        int numDocs = randomIntBetween(5, 20);
+        Map<Integer, byte[]> docIdToSource = new HashMap<>();
+
+        // Add documents in multiple segments
+        for (int i = 0; i < numDocs; i++) {
+            byte[] source = randomByteArrayOfLength(randomIntBetween(10, 100));
+            docIdToSource.put(i, source);
+            Document doc = new Document();
+            doc.add(new StoredField("_source", source));
+            multiWriter.addDocument(doc);
+            if (rarely()) {
+                multiWriter.commit(); // Force new segment
+            }
+        }
+        multiWriter.commit();
+
+        DirectoryReader multiReader = DirectoryReader.open(multiWriter);
+        assertTrue("Should have multiple segments", multiReader.leaves().size() > 1);
+
+        // Create a map to store segment-based sources
+        Map<String, Map<Integer, byte[]>> segmentSources = new HashMap<>();
+
+        // Initialize segment sources
+        int docBase = 0;
+        for (LeafReaderContext ctx : multiReader.leaves()) {
+            Map<Integer, byte[]> segmentMap = new HashMap<>();
+            for (int i = 0; i < ctx.reader().maxDoc(); i++) {
+                segmentMap.put(i, docIdToSource.get(docBase + i));
+            }
+            segmentSources.put(ctx.reader().toString(), segmentMap);
+            docBase += ctx.reader().maxDoc();
+        }
+
+        DerivedSourceDirectoryReader derivedReader = DerivedSourceDirectoryReader.wrap(multiReader, (leafReader, docId) -> {
+            // Use the segment-specific map to get the correct source
+            Map<Integer, byte[]> segmentMap = segmentSources.get(leafReader.toString());
+            return new BytesArray(segmentMap.get(docId));
+        });
+
+        int processedDocs = 0;
+        // Verify all documents across all segments
+        for (LeafReaderContext context : derivedReader.leaves()) {
+            StoredFields storedFields = context.reader().storedFields();
+            for (int i = 0; i < context.reader().maxDoc(); i++) {
+                final int globalDocId = context.docBase + i;
+                final int localDocId = i;
+                StoredFieldVisitor visitor = new StoredFieldVisitor() {
+                    @Override
+                    public Status needsField(FieldInfo fieldInfo) {
+                        return fieldInfo.name.equals("_source") ? Status.YES : Status.NO;
+                    }
+
+                    @Override
+                    public void binaryField(FieldInfo fieldInfo, byte[] value) {
+                        assertArrayEquals("Source content should match for doc " + globalDocId, docIdToSource.get(globalDocId), value);
+                    }
+                };
+                storedFields.document(localDocId, visitor);
+                processedDocs++;
+            }
+        }
+
+        assertEquals("Should have processed all documents", numDocs, processedDocs);
+        IOUtils.close(derivedReader, multiReader, multiWriter, multiDir);
+    }
+
+}

--- a/server/src/test/java/org/opensearch/common/lucene/index/DerivedSourceLeafReaderTests.java
+++ b/server/src/test/java/org/opensearch/common/lucene/index/DerivedSourceLeafReaderTests.java
@@ -1,0 +1,189 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.lucene.index;
+
+import org.apache.lucene.codecs.StoredFieldsReader;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.CodecReader;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.FilterLeafReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.StoredFieldVisitor;
+import org.apache.lucene.index.StoredFields;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomCodec;
+import org.opensearch.common.CheckedFunction;
+import org.opensearch.common.util.io.IOUtils;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+public class DerivedSourceLeafReaderTests extends OpenSearchTestCase {
+
+    private Directory dir;
+    private IndexWriter writer;
+    private DirectoryReader directoryReader;
+    private LeafReader leafReader;
+    private DerivedSourceLeafReader reader;
+    private static final byte[] TEST_SOURCE = "{\"field\":\"value\"}".getBytes(StandardCharsets.UTF_8);
+    private final CheckedFunction<Integer, BytesReference, IOException> sourceProvider = docId -> new BytesArray(TEST_SOURCE);
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        dir = newDirectory();
+        IndexWriterConfig config = newIndexWriterConfig(random(), null).setCodec(new RandomCodec(random()));
+        writer = new IndexWriter(dir, config);
+
+        Document doc = new Document();
+        doc.add(new StoredField("_source", TEST_SOURCE));
+        writer.addDocument(doc);
+        writer.commit();
+
+        directoryReader = DirectoryReader.open(writer);
+        leafReader = directoryReader.leaves().get(0).reader();
+        reader = new DerivedSourceLeafReader(leafReader, sourceProvider);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        IOUtils.close(directoryReader, writer, dir);
+        super.tearDown();
+    }
+
+    public void testStoredFields() throws IOException {
+        StoredFields storedFields = reader.storedFields();
+        assertNotNull("StoredFields should not be null", storedFields);
+        assertTrue(
+            "StoredFields should be DerivedSourceStoredFields",
+            storedFields instanceof DerivedSourceStoredFieldsReader.DerivedSourceStoredFields
+        );
+    }
+
+    public void testGetSequentialStoredFieldsReaderWithCodecReader() throws IOException {
+        assumeTrue("Test requires CodecReader", leafReader instanceof CodecReader);
+
+        StoredFieldsReader sequentialReader = reader.getSequentialStoredFieldsReader();
+        assertNotNull("Sequential reader should not be null", sequentialReader);
+        assertTrue(
+            "Sequential reader should be DerivedSourceStoredFieldsReader",
+            sequentialReader instanceof DerivedSourceStoredFieldsReader
+        );
+    }
+
+    public void testGetSequentialStoredFieldsReaderWithSequentialReader() throws IOException {
+        // Create a wrapped SequentialStoredFieldsLeafReader
+        LeafReader sequentialLeafReader = new SequentialStoredFieldsLeafReader(leafReader) {
+            @Override
+            protected StoredFieldsReader doGetSequentialStoredFieldsReader(StoredFieldsReader reader) {
+                return reader;
+            }
+
+            @Override
+            public CacheHelper getCoreCacheHelper() {
+                return in.getCoreCacheHelper();
+            }
+
+            @Override
+            public CacheHelper getReaderCacheHelper() {
+                return in.getReaderCacheHelper();
+            }
+
+            @Override
+            public StoredFieldsReader getSequentialStoredFieldsReader() throws IOException {
+                return ((CodecReader) in).getFieldsReader();
+            }
+        };
+
+        DerivedSourceLeafReader sequentialDerivedReader = new DerivedSourceLeafReader(sequentialLeafReader, sourceProvider);
+        StoredFieldsReader sequentialReader = sequentialDerivedReader.getSequentialStoredFieldsReader();
+
+        assertNotNull("Sequential reader should not be null", sequentialReader);
+        assertTrue(
+            "Sequential reader should be DerivedSourceStoredFieldsReader",
+            sequentialReader instanceof DerivedSourceStoredFieldsReader
+        );
+    }
+
+    public void testGetSequentialStoredFieldsReaderWithInvalidReader() {
+        LeafReader invalidReader = new FilterLeafReader(leafReader) {
+            @Override
+            public CacheHelper getCoreCacheHelper() {
+                return in.getCoreCacheHelper();
+            }
+
+            @Override
+            public CacheHelper getReaderCacheHelper() {
+                return in.getReaderCacheHelper();
+            }
+        };
+
+        DerivedSourceLeafReader invalidDerivedReader = new DerivedSourceLeafReader(invalidReader, sourceProvider);
+
+        expectThrows(IOException.class, invalidDerivedReader::getSequentialStoredFieldsReader);
+    }
+
+    public void testGetCoreAndReaderCacheHelper() {
+        assertEquals("Core cache helper should match input reader", leafReader.getCoreCacheHelper(), reader.getCoreCacheHelper());
+        assertEquals("Reader cache helper should match input reader", leafReader.getReaderCacheHelper(), reader.getReaderCacheHelper());
+    }
+
+    public void testWithRandomDocuments() throws IOException {
+        Directory randomDir = newDirectory();
+        IndexWriterConfig config = newIndexWriterConfig(random(), null).setCodec(new RandomCodec(random()));
+        IndexWriter randomWriter = new IndexWriter(randomDir, config);
+
+        int numDocs = randomIntBetween(1, 10);
+        Map<Integer, byte[]> docIdToSource = new HashMap<>();
+
+        for (int i = 0; i < numDocs; i++) {
+            byte[] source = randomByteArrayOfLength(randomIntBetween(10, 50));
+            docIdToSource.put(i, source);
+            Document doc = new Document();
+            doc.add(new StoredField("_source", source));
+            randomWriter.addDocument(doc);
+        }
+        randomWriter.commit();
+
+        DirectoryReader randomDirectoryReader = DirectoryReader.open(randomWriter);
+        LeafReader randomLeafReader = randomDirectoryReader.leaves().get(0).reader();
+        DerivedSourceLeafReader randomDerivedReader = new DerivedSourceLeafReader(
+            randomLeafReader,
+            docId -> new BytesArray(docIdToSource.get(docId))
+        );
+
+        StoredFields storedFields = randomDerivedReader.storedFields();
+        for (int docId = 0; docId < numDocs; docId++) {
+            final int currentDocId = docId;
+            StoredFieldVisitor visitor = new StoredFieldVisitor() {
+                @Override
+                public Status needsField(FieldInfo fieldInfo) {
+                    return fieldInfo.name.equals("_source") ? Status.YES : Status.NO;
+                }
+
+                @Override
+                public void binaryField(FieldInfo fieldInfo, byte[] value) {
+                    assertArrayEquals("Source content should match for doc " + currentDocId, docIdToSource.get(currentDocId), value);
+                }
+            };
+            storedFields.document(docId, visitor);
+        }
+
+        IOUtils.close(randomDirectoryReader, randomWriter, randomDir);
+    }
+}

--- a/server/src/test/java/org/opensearch/common/lucene/index/DerivedSourceStoredFieldsReaderTests.java
+++ b/server/src/test/java/org/opensearch/common/lucene/index/DerivedSourceStoredFieldsReaderTests.java
@@ -1,0 +1,150 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.common.lucene.index;
+
+import org.apache.lucene.codecs.StoredFieldsReader;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.StoredFieldVisitor;
+import org.apache.lucene.index.StoredFields;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.analysis.MockAnalyzer;
+import org.opensearch.common.util.io.IOUtils;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.test.OpenSearchTestCase;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class DerivedSourceStoredFieldsReaderTests extends OpenSearchTestCase {
+
+    private Directory dir;
+    private IndexWriter writer;
+    private StoredFieldsReader delegate;
+    private DerivedSourceStoredFieldsReader reader;
+    private static final byte[] TEST_SOURCE = "{\"field\":\"value\"}".getBytes(StandardCharsets.UTF_8);
+    private static final int TEST_DOC_ID = 0;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        dir = newDirectory();
+        IndexWriterConfig config = newIndexWriterConfig(new MockAnalyzer(random()));
+        writer = new IndexWriter(dir, config);
+
+        Document doc = new Document();
+        doc.add(new StoredField("_source", TEST_SOURCE));
+        writer.addDocument(doc);
+        writer.commit();
+
+        DirectoryReader dirReader = DirectoryReader.open(writer);
+        delegate = new StoredFieldsReader() {
+            private final StoredFields storedFields = dirReader.leaves().get(0).reader().storedFields();
+
+            @Override
+            public void document(int docID, StoredFieldVisitor visitor) throws IOException {
+                storedFields.document(docID, visitor);
+            }
+
+            @Override
+            public StoredFieldsReader clone() {
+                return this;
+            }
+
+            @Override
+            public void checkIntegrity() throws IOException {}
+
+            @Override
+            public void close() throws IOException {
+                dirReader.close();
+            }
+        };
+
+        reader = new DerivedSourceStoredFieldsReader(delegate, docId -> new BytesArray(TEST_SOURCE));
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        IOUtils.close(reader, writer, dir);
+        super.tearDown();
+    }
+
+    public void testClone() {
+        StoredFieldsReader cloned = reader.clone();
+        assertNotNull("Cloned reader should not be null", cloned);
+        assertTrue(
+            "Cloned reader should be instance of DerivedSourceStoredFieldsReader",
+            cloned instanceof DerivedSourceStoredFieldsReader
+        );
+    }
+
+    public void testCheckIntegrity() throws IOException {
+        // Should not throw exception
+        reader.checkIntegrity();
+    }
+
+    public void testGetMergeInstance() {
+        StoredFieldsReader mergeInstance = reader.getMergeInstance();
+        assertNotNull("Merge instance should not be null", mergeInstance);
+    }
+
+    public void testDocumentWithSourceFieldRequested() throws IOException {
+        final AtomicBoolean sourceCalled = new AtomicBoolean(false);
+        StoredFieldVisitor visitor = new StoredFieldVisitor() {
+            @Override
+            public Status needsField(FieldInfo fieldInfo) {
+                return fieldInfo.name.equals("_source") ? Status.YES : Status.NO;
+            }
+
+            @Override
+            public void binaryField(FieldInfo fieldInfo, byte[] value) {
+                sourceCalled.set(true);
+                assertEquals("Field name should be _source", "_source", fieldInfo.name);
+                assertArrayEquals("Source field content should match", TEST_SOURCE, value);
+            }
+        };
+
+        reader.document(TEST_DOC_ID, visitor);
+        assertTrue("Source field should have been called", sourceCalled.get());
+    }
+
+    public void testDocumentWithoutSourceFieldRequested() throws IOException {
+        StoredFieldVisitor visitor = new StoredFieldVisitor() {
+            @Override
+            public Status needsField(FieldInfo fieldInfo) {
+                return Status.NO;
+            }
+
+            @Override
+            public void binaryField(FieldInfo fieldInfo, byte[] value) {
+                fail("Binary field should not be called when source is not requested");
+            }
+        };
+        reader.document(TEST_DOC_ID, visitor);
+    }
+
+    public void testSourceProviderThrowsException() {
+        reader = new DerivedSourceStoredFieldsReader(delegate, docId -> { throw new IOException("Test exception"); });
+        StoredFieldVisitor visitor = new StoredFieldVisitor() {
+            @Override
+            public Status needsField(FieldInfo fieldInfo) {
+                return Status.YES;
+            }
+        };
+
+        expectThrows(IOException.class, () -> reader.document(TEST_DOC_ID, visitor));
+    }
+}

--- a/server/src/test/java/org/opensearch/index/engine/ReadOnlyEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/ReadOnlyEngineTests.java
@@ -147,7 +147,7 @@ public class ReadOnlyEngineTests extends EngineTestCase {
                 assertThat(readOnlyEngine.getProcessedLocalCheckpoint(), equalTo(readOnlyEngine.getPersistedLocalCheckpoint()));
                 assertThat(readOnlyEngine.getSeqNoStats(globalCheckpoint.get()).getMaxSeqNo(), equalTo(lastSeqNoStats.getMaxSeqNo()));
                 assertThat(getDocIds(readOnlyEngine, false), equalTo(lastDocIds));
-                try (Engine.GetResult getResult = readOnlyEngine.get(get, readOnlyEngine::acquireSearcher)) {
+                try (Engine.GetResult getResult = readOnlyEngine.get(get, createMapperService(), readOnlyEngine::acquireSearcher)) {
                     assertTrue(getResult.exists());
                 }
             }

--- a/server/src/test/java/org/opensearch/index/engine/TranslogLeafReaderTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/TranslogLeafReaderTests.java
@@ -1,0 +1,255 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.index.engine;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.StoredFieldVisitor;
+import org.apache.lucene.index.StoredFields;
+import org.opensearch.Version;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.index.Index;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.index.IndexSettings;
+import org.opensearch.index.codec.CodecService;
+import org.opensearch.index.fieldvisitor.FieldsVisitor;
+import org.opensearch.index.mapper.DocumentMapper;
+import org.opensearch.index.mapper.IdFieldMapper;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.index.mapper.ParseContext;
+import org.opensearch.index.mapper.ParsedDocument;
+import org.opensearch.index.mapper.RoutingFieldMapper;
+import org.opensearch.index.mapper.SeqNoFieldMapper;
+import org.opensearch.index.mapper.SourceFieldMapper;
+import org.opensearch.index.mapper.Uid;
+import org.opensearch.index.seqno.RetentionLeases;
+import org.opensearch.index.translog.Translog;
+import org.opensearch.test.IndexSettingsModule;
+import org.opensearch.test.OpenSearchTestCase;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TranslogLeafReaderTests extends OpenSearchTestCase {
+
+    private MapperService mapperService;
+    private EngineConfig engineConfig;
+    private Translog.Index operation;
+    private TranslogLeafReader translogLeafReader;
+    private DocumentMapper documentMapper;
+    private Index index;
+    private BytesReference source;
+    private IndexSettings defaultIndexSettings;
+
+    @Before
+    public void setup() throws Exception {
+        index = new Index("test", "_uuid");
+        final IndexMetadata defaultIndexMetadata = IndexMetadata.builder("test")
+            .settings(settings(Version.CURRENT))
+            .numberOfShards(1)
+            .numberOfReplicas(1)
+            .build();
+        defaultIndexSettings = IndexSettingsModule.newIndexSettings("test", defaultIndexMetadata.getSettings());
+        mapperService = mock(MapperService.class);
+        when(mapperService.getIndexSettings()).thenReturn(defaultIndexSettings);
+        documentMapper = mock(DocumentMapper.class);
+        when(mapperService.documentMapper()).thenReturn(documentMapper);
+        when(mapperService.index()).thenReturn(index);
+
+        engineConfig = new EngineConfig.Builder().indexSettings(defaultIndexSettings)
+            .retentionLeasesSupplier(() -> RetentionLeases.EMPTY)
+            .codecService(new CodecService(null, defaultIndexSettings, logger))
+            .build();
+
+        // Setup basic operation
+        source = new BytesArray("{\"field\":1}");
+        operation = new Translog.Index("test", 1L, 1L, 1L, source.toBytesRef().bytes, "routing", 1);
+
+        // Initialize the reader
+        translogLeafReader = new TranslogLeafReader(operation, mapperService, engineConfig);
+    }
+
+    public void testBasicProperties() {
+        assertEquals(1, translogLeafReader.numDocs());
+        assertEquals(1, translogLeafReader.maxDoc());
+    }
+
+    public void testStoredFieldsAccess() throws IOException {
+        StoredFields storedFields = translogLeafReader.storedFields();
+        assertNotNull(storedFields);
+
+        // Test accessing invalid document ID
+        expectThrows(IllegalArgumentException.class, () -> {
+            storedFields.document(1, new FieldsVisitor(true) {
+            });
+        });
+    }
+
+    public void testSourceFieldAccess() throws IOException {
+        StoredFields storedFields = translogLeafReader.storedFields();
+
+        final BytesReference[] sourceRef = new BytesReference[1];
+        StoredFieldVisitor visitor = new StoredFieldVisitor() {
+            @Override
+            public void binaryField(FieldInfo fieldInfo, byte[] value) {
+                if (fieldInfo.name.equals(SourceFieldMapper.NAME)) {
+                    sourceRef[0] = new BytesArray(value);
+                }
+            }
+
+            @Override
+            public Status needsField(FieldInfo fieldInfo) {
+                return fieldInfo.name.equals(SourceFieldMapper.NAME) ? Status.YES : Status.NO;
+            }
+        };
+
+        storedFields.document(0, visitor);
+        assertNotNull(sourceRef[0]);
+        assertEquals(operation.source(), sourceRef[0]);
+    }
+
+    public void testIdFieldAccess() throws IOException {
+        StoredFields storedFields = translogLeafReader.storedFields();
+
+        final BytesReference[] idRef = new BytesReference[1];
+        StoredFieldVisitor visitor = new StoredFieldVisitor() {
+            @Override
+            public void binaryField(FieldInfo fieldInfo, byte[] value) {
+                if (fieldInfo.name.equals(IdFieldMapper.NAME)) {
+                    idRef[0] = new BytesArray(Uid.decodeId(value));
+                }
+            }
+
+            @Override
+            public Status needsField(FieldInfo fieldInfo) {
+                return fieldInfo.name.equals(IdFieldMapper.NAME) ? Status.YES : Status.NO;
+            }
+        };
+
+        storedFields.document(0, visitor);
+        assertNotNull(idRef[0]);
+        assertEquals(operation.id(), idRef[0].utf8ToString());
+    }
+
+    public void testRoutingFieldAccess() throws IOException {
+        StoredFields storedFields = translogLeafReader.storedFields();
+
+        final String[] routingVal = new String[1];
+        StoredFieldVisitor visitor = new StoredFieldVisitor() {
+            @Override
+            public void stringField(FieldInfo fieldInfo, String value) {
+                if (fieldInfo.name.equals(RoutingFieldMapper.NAME)) {
+                    routingVal[0] = value;
+                }
+            }
+
+            @Override
+            public Status needsField(FieldInfo fieldInfo) {
+                return fieldInfo.name.equals(RoutingFieldMapper.NAME) ? Status.YES : Status.NO;
+            }
+        };
+
+        storedFields.document(0, visitor);
+        assertNotNull(routingVal[0]);
+        assertEquals(operation.routing(), routingVal[0]);
+    }
+
+    // TODO: Update derived source index setting
+    public void testDerivedSourceFields() throws IOException {
+        // Setup mapper service with derived source enabled
+        Settings derivedSourceSettings = Settings.builder()
+            .put(defaultIndexSettings.getSettings())
+            .put("index.derive_source", true)
+            .build();
+        IndexMetadata derivedMetadata = IndexMetadata.builder("test").settings(derivedSourceSettings).build();
+        IndexSettings derivedIndexSettings = new IndexSettings(derivedMetadata, Settings.EMPTY);
+
+        when(mapperService.getIndexSettings()).thenReturn(derivedIndexSettings);
+
+        // Mock document mapper
+        Document doc = new Document();
+        doc.add(new StringField("field", "value", Field.Store.YES));
+        ParsedDocument parsedDoc = new ParsedDocument(null, null, "1", null, null, source, MediaTypeRegistry.JSON, null);
+        when(mapperService.documentMapper().parse(any())).thenReturn(parsedDoc);
+
+        StoredFields storedFields = translogLeafReader.storedFields();
+
+        final BytesReference[] sourceRef = new BytesReference[1];
+        StoredFieldVisitor visitor = new StoredFieldVisitor() {
+            @Override
+            public void binaryField(org.apache.lucene.index.FieldInfo fieldInfo, byte[] value) {
+                if (fieldInfo.name.equals(SourceFieldMapper.NAME)) {
+                    sourceRef[0] = new BytesArray(value);
+                }
+            }
+
+            @Override
+            public Status needsField(org.apache.lucene.index.FieldInfo fieldInfo) {
+                return fieldInfo.name.equals(SourceFieldMapper.NAME) ? Status.YES : Status.NO;
+            }
+        };
+
+        storedFields.document(0, visitor);
+        assertNotNull(sourceRef[0]);
+    }
+
+    public void testUnsupportedOperations() {
+        // Test various unsupported operations
+        expectThrows(UnsupportedOperationException.class, () -> translogLeafReader.terms("field"));
+        expectThrows(UnsupportedOperationException.class, () -> translogLeafReader.getNumericDocValues("field"));
+        expectThrows(UnsupportedOperationException.class, () -> translogLeafReader.getBinaryDocValues("field"));
+        expectThrows(UnsupportedOperationException.class, () -> translogLeafReader.getSortedDocValues("field"));
+        expectThrows(UnsupportedOperationException.class, () -> translogLeafReader.getPointValues("field"));
+        expectThrows(UnsupportedOperationException.class, () -> translogLeafReader.getLiveDocs());
+    }
+
+    public void testCreateInMemoryIndexReader() throws IOException {
+        // Setup test document
+        Document doc = new Document();
+        doc.add(new StringField("field", "value", Field.Store.YES));
+        // Create SeqID for the ParsedDocument
+        SeqNoFieldMapper.SequenceIDFields seqID = SeqNoFieldMapper.SequenceIDFields.emptySeqID();
+        ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
+        buffer.putLong(1L);
+
+        final ParseContext.Document document = new ParseContext.Document();
+        document.add(seqID.seqNo);
+        document.add(seqID.seqNoDocValue);
+        document.add(seqID.primaryTerm);
+
+        ParsedDocument parsedDoc = new ParsedDocument(
+            new NumericDocValuesField("version", 1),
+            seqID,
+            operation.id(),
+            null,
+            Collections.singletonList(document),
+            source,
+            MediaTypeRegistry.JSON,
+            null
+        );
+
+        // Mock necessary components
+        when(mapperService.documentMapper().parse(any())).thenReturn(parsedDoc);
+
+        // Test creation of in-memory reader
+        assertNotNull(TranslogLeafReader.createInMemoryIndexReader(operation, mapperService, engineConfig));
+    }
+}

--- a/server/src/test/java/org/opensearch/index/shard/RefreshListenersTests.java
+++ b/server/src/test/java/org/opensearch/index/shard/RefreshListenersTests.java
@@ -95,6 +95,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import static org.opensearch.common.unit.TimeValue.timeValueMillis;
+import static org.opensearch.index.engine.EngineTestCase.createMapperService;
 import static org.hamcrest.Matchers.arrayContaining;
 
 /**
@@ -369,7 +370,7 @@ public class RefreshListenersTests extends OpenSearchTestCase {
                         listener.assertNoError();
 
                         Engine.Get get = new Engine.Get(false, false, threadId, new Term(IdFieldMapper.NAME, threadId));
-                        try (Engine.GetResult getResult = engine.get(get, engine::acquireSearcher)) {
+                        try (Engine.GetResult getResult = engine.get(get, createMapperService(), engine::acquireSearcher)) {
                             assertTrue("document not found", getResult.exists());
                             assertEquals(iteration, getResult.version());
                             StoredFields storedFields = getResult.docIdAndVersion().reader.storedFields();


### PR DESCRIPTION
### Description
- Integrating derive source feature in get and search path
- Tested this integration for various cases.
- Added integration tests for all relevant paths like create/update/get/search/reindex.

### Considerations:
- For the scenarios where we read from the translog, we have created the in-memory lucene index, which will ensure that we derive source from lucene docValues and stored fields only instead of reading _source directly from translog. This will help in making final resulted source consistent in terms of various fields(like Date, GeoPoint(we always return in lat/lon pair, input source can have different format like geohash)) where display format can vary as compared to suppkied format passed during ingestion.

This PR is a continuation of #17759

### Related Issues
Resolves #17073
<!-- List any other related issues here -->
Part of feature #9568

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).